### PR TITLE
Making LavAtmos output file compliant to protocol

### DIFF
--- a/protocol/outputs/lavatmos/static-lavatmos-trappist1b-tau5-hot-data.csv
+++ b/protocol/outputs/lavatmos/static-lavatmos-trappist1b-tau5-hot-data.csv
@@ -1,2 +1,2 @@
-z(m),ptot(bar),T(K),pH2O(bar)
+z(m),p_tot(bar),T(K),p_H2O(bar)
 0,107,1870,0.9892721493079558


### PR DESCRIPTION
Change the header of LavAtmos output file compliant with protocol.
- What it was: z(m),ptot(bar),T(K),pH2O(bar)
- What it should be: z(m),p_tot(bar),T(K),p_H2O(bar)