### PR TITLE
Making MOAChi output file compliant to protocol

### DIFF
--- a/protocol/outputs/moachi/static-moachi-trappist1b-tau5-surface.csv
+++ b/protocol/outputs/moachi/static-moachi-trappist1b-tau5-surface.csv
@@ -1,2 +1,3 @@
-T_surf(K),phi(vol_frac),p_surf(bar),p_H2O(bar)
+T_surf(K),phi(vol_frac),p_tot(bar),p_H2O(bar)
 2190.534448,0.292756146,295.001361,2.466500714
+


### PR DESCRIPTION
Change in header of MOAChi output file to make it compliant to protocol.
- What it was: T_surf(K),phi(vol_frac),p_surf(bar),p_H2O(bar)
- What it should be: T_surf(K),phi(vol_frac),p_tot(bar),p_H2O(bar)