### PR TITLE
Update CHILI protocol paper link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 <p align="center">
      <a href="https://doi.org/10.5281/zenodo.17312304">
           <img src="https://zenodo.org/badge/991899932.svg" alt="Zenodo DOI"></a>
+     <a href="https://arxiv.org/abs/2511.16142">
+          <img src="https://img.shields.io/badge/arXiv-2511.16142-red"
+     alt="arXiv preprint"></a>
 </p>
 
 <h1 align="center">CHILI: Coupled atmospHere Interior modeL Intercomparison<br>


### PR DESCRIPTION
Updated the instructions in the `README.md` to include a direct link to the CHILI protocol paper on arXiv, replacing the placeholder text.